### PR TITLE
Add support for haml-5

### DIFF
--- a/haml-i18n-extractor.gemspec
+++ b/haml-i18n-extractor.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.version       = Haml::I18n::Extractor::VERSION
 
   gem.add_dependency "tilt"
-  gem.add_dependency "haml"
+  gem.add_dependency "haml", ">= 5.0.0.beta.2"
   gem.add_dependency "activesupport"
   gem.add_dependency "highline"
   gem.add_dependency "trollop", "1.16.2"

--- a/lib/haml-i18n-extractor/extraction/extractor.rb
+++ b/lib/haml-i18n-extractor/extraction/extractor.rb
@@ -164,8 +164,8 @@ module Haml
 
 
       def validate_haml(haml)
-        parser = Haml::Parser.new(haml, Haml::Options.new)
-        parser.parse
+        parser = Haml::Parser.new(Haml::Options.new)
+        parser.call(haml)
       rescue Haml::SyntaxError => e
         message = "invalid syntax for haml #{@haml_reader.path}\n"
         message << "original error:\n"

--- a/lib/haml-i18n-extractor/extraction/haml_parser.rb
+++ b/lib/haml-i18n-extractor/extraction/haml_parser.rb
@@ -6,12 +6,14 @@ module Haml
       class HamlParser < Haml::Parser
 
         def initialize(haml)
-          super(haml, Haml::Options.new)
+          super(Haml::Options.new)
+
+          @haml = haml
         end
 
         def flattened_values
           # make the haml we passed in a parse tree!
-          @ht_parse_tree = self.parse 
+          @ht_parse_tree = self.call(haml)
           ret = flatten_tree_attrs(@ht_parse_tree,[])
           ret[1..-2] # we only want the actual lines, not the root node and last line which don't really exist
           #ret
@@ -30,6 +32,8 @@ module Haml
         end
 
         private
+
+        attr_reader :haml
 
         def node_attributes(node)
           attrs = {}

--- a/lib/haml-i18n-extractor/version.rb
+++ b/lib/haml-i18n-extractor/version.rb
@@ -1,7 +1,7 @@
 module Haml
   module I18n
     class Extractor
-      VERSION = "0.5.9"
+      VERSION = "0.6.0"
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,11 +32,11 @@ class MiniTest::Unit::TestCase
     return engine.to_html(base) if base
     engine.to_html(scope, locals, &block)
   end
-  
+
   def assert_warning(message)
     the_real_stderr, $stderr = $stderr, StringIO.new
     yield
-  
+
     if message.is_a?(Regexp)
       assert_match message, $stderr.string.strip
     else
@@ -45,15 +45,15 @@ class MiniTest::Unit::TestCase
   ensure
     $stderr = the_real_stderr
   end
-  
+
   def silence_warnings(&block)
     Haml::Util.silence_warnings(&block)
   end
-  
+
   def rails_form_opener
     '<div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div>'
   end
-  
+
   def assert_raises_message(klass, message)
     yield
   rescue Exception => e
@@ -62,7 +62,7 @@ class MiniTest::Unit::TestCase
   else
     flunk "Expected exception #{klass}, none raised"
   end
-  
+
   def self.error(*args)
     Haml::Error.message(*args)
   end
@@ -114,7 +114,7 @@ module TestHelper
   def self.hax_shit
     Dir.glob("*yml").map {|p| FileUtils.rm(p) } # HAX, TODO: handle with yaml files correctly (config/en.yml)
     Dir.glob("config/locales/*yml").map {|p| FileUtils.rm(p) } # HAX, TODO: handle with yaml files correctly (config/en.yml)
-    if File.exists?(Haml::I18n::Extractor::TaggingWriter::DB)
+    if File.exist?(Haml::I18n::Extractor::TaggingWriter::DB)
       FileUtils.rm_rf(Haml::I18n::Extractor::TaggingWriter::DB) # HAX, TODO: setup/teardown
     end
   end
@@ -165,5 +165,5 @@ EOH
   def self.teardown_project_directory!
     FileUtils.rm_rf(PROJECT_DIR)
   end
-  
+
 end


### PR DESCRIPTION
This PR modifies the parser to be compatible with Haml 5. I've tried to run tests but there are a lot of warnings and many tests relies on interactivity so I'm not sure what the best approach for that.

@shaiguitar are you able to help with that?